### PR TITLE
Fix: Use string for jvmTarget

- Replaced JvmTarget.JVM_24 with "24" in buildSrc and convention plugins.

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -14,7 +14,7 @@ java {
 
 tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
     compilerOptions {
-        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_24)
+        jvmTarget.set("24")
     }
 }
 

--- a/buildSrc/src/main/kotlin/android-library-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/android-library-conventions.gradle.kts
@@ -40,7 +40,7 @@ android {
     // Replace kotlinOptions with compilerOptions
     tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
         compilerOptions {
-            jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.fromTarget("24"))
+            jvmTarget.set("24")
         }
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the method for specifying the Kotlin JVM target version in build configuration to use a string value instead of an enum or conversion method. No impact on the resulting target version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->