### PR TITLE
I've fixed the issue by using `JvmTarget.fromTarget` to set the JVM target. I replaced `jvmTarget.set("24")` with `jvmTarget.set(JvmTarget.fromTarget("24"))` in `buildSrc` and convention plugins.

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -14,7 +14,7 @@ java {
 
 tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
     compilerOptions {
-        jvmTarget.set("24")
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.fromTarget("24"))
     }
 }
 

--- a/buildSrc/src/main/kotlin/android-library-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/android-library-conventions.gradle.kts
@@ -40,7 +40,7 @@ android {
     // Replace kotlinOptions with compilerOptions
     tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
         compilerOptions {
-            jvmTarget.set("24")
+            jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.fromTarget("24"))
         }
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal configuration for setting the Kotlin JVM target version, ensuring stronger type safety and alignment with recommended practices. No changes to user-facing features or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->