### PR TITLE
Fixed the `jvmTarget` assignment.

- Replaced `jvmTarget.set("24")` with `jvmTarget = "24"` in `buildSrc` and convention plugins.

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -15,7 +15,7 @@ java {
 
 tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
     compilerOptions {
-        jvmTarget.set("24")
+        jvmTarget = "24"
     }
 }
 

--- a/buildSrc/src/main/kotlin/android-library-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/android-library-conventions.gradle.kts
@@ -40,7 +40,7 @@ android {
     // Replace kotlinOptions with compilerOptions
     tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
         compilerOptions {
-            jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.fromTarget("24"))
+            jvmTarget = "24"
         }
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the configuration syntax for setting the Kotlin JVM target version to use direct property assignment instead of setter methods. No changes to functionality or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->