### PR TITLE
fix(build): Remove incorrect plugin dependencies in buildSrc

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -36,10 +36,6 @@ dependencies {
     testImplementation(gradleTestKit())
 
    
-    implementation(libs.findPlugin("android.application").get())
-    implementation(libs.findPlugin("kotlin.android").get())
-    implementation(libs.findPlugin("ksp").get())
-    implementation(libs.findPlugin("hilt.android").get())
     implementation(libs.findLibrary("spotless.gradle.plugin").get())
     implementation(libs.findLibrary("detekt.gradle.plugin").get())
 }


### PR DESCRIPTION
The build was failing with the error "Cannot convert the provided notation to an object of type Dependency: com.android.application:8.11.1".

This was caused by incorrectly declaring Gradle plugins (`com.android.application`, `org.jetbrains.kotlin.android`, etc.) as `implementation` dependencies in `buildSrc/build.gradle.kts`.

These plugins are meant to be applied in convention plugin scripts, not consumed as libraries by `buildSrc` itself. This commit removes these erroneous dependency declarations to resolve the build configuration error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal build configuration by removing unused plugin dependencies. No impact on user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->