### PR TITLE
fix(build): Correct buildSrc plugin dependencies

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -36,8 +36,12 @@ dependencies {
     testImplementation(gradleTestKit())
 
    
-    implementation(libs.findLibrary("spotless.gradle.plugin").get())
-    implementation(libs.findLibrary("detekt.gradle.plugin").get())
+    implementation(libs.android.gradle.plugin)
+    implementation(libs.kotlin.gradle.plugin)
+    implementation(libs.ksp.gradle.plugin)
+    implementation(libs.hilt.android.gradle.plugin)
+    implementation(libs.spotless.gradle.plugin)
+    implementation(libs.detekt.gradle.plugin)
 }
 
 tasks.test {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -84,6 +84,13 @@ firebase-crashlytics = { id = "com.google.firebase.crashlytics", version.ref = "
 # Plugins
 spotless-gradle-plugin = { group = "com.diffplug.spotless", name = "spotless-plugin-gradle", version.ref = "spotless" }
 detekt-gradle-plugin = { group = "io.gitlab.arturbosch.detekt", name = "detekt-gradle-plugin", version.ref = "detekt" }
+
+# Gradle Plugins for buildSrc classpath
+android-gradle-plugin = { group = "com.android.tools.build", name = "gradle", version.ref = "agp" }
+kotlin-gradle-plugin = { group = "org.jetbrains.kotlin", name = "kotlin-gradle-plugin", version.ref = "kotlin" }
+ksp-gradle-plugin = { group = "com.google.devtools.ksp", name = "symbol-processing-gradle-plugin", version.ref = "ksp" }
+hilt-android-gradle-plugin = { group = "com.google.dagger", name = "hilt-android-gradle-plugin", version.ref = "hilt" }
+
 # AndroidX
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
 androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }


### PR DESCRIPTION
The build was failing with an error about converting plugin notations to dependencies. This was caused by using `libs.findPlugin(...)` in the `buildSrc/build.gradle.kts` dependencies block, which is incorrect.

This commit fixes the issue by:
1.  Adding proper library aliases to `gradle/libs.versions.toml` for the required Gradle plugins (AGP, Kotlin, KSP, Hilt).
2.  Updating `buildSrc/build.gradle.kts` to use these new, correct library aliases.

This ensures that the necessary plugins are correctly placed on the `buildSrc` classpath, resolving both the initial build error and the subsequent "plugin not found" error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded the set of build plugins available, including support for Android, Kotlin, KSP, and Hilt plugins.
  * Updated dependency management to include new plugin entries for improved build configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->