### PR TITLE
feat: Upgrade Gradle version to 9.0-milestone-1

This commit updates the Gradle Wrapper to use version 9.0-milestone-1. This is necessary to ensure compatibility with the Kotlin version and features used in the project's build scripts.

The `distributionUrl` in `gradle/wrapper/gradle-wrapper.properties` has been updated accordingly.

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -42,7 +42,6 @@ dependencies {
     implementation("com.google.dagger:hilt-android-gradle-plugin:2.57")
     implementation("com.diffplug.spotless:spotless-plugin-gradle:6.25.0")
     implementation("io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.23.6")
-
 }
 
 tasks.test {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 # Updated for Java 21 compatibility
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.0-milestone-1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Gradle wrapper to a newer version.
  * Cleaned up unnecessary whitespace in build configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->